### PR TITLE
Add OpenTUI adapter error logging and tests

### DIFF
--- a/src/testing/capture/adapters/opentui.test.ts
+++ b/src/testing/capture/adapters/opentui.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { OpenTUITestAdapter } from "./opentui";
+
+describe("OpenTUITestAdapter", () => {
+	test("logs descriptive error when spec import fails", async () => {
+		const logs: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+		const adapter = new OpenTUITestAdapter({
+			importModule: () => Promise.reject(new Error("module not found")),
+			render: () => Promise.resolve(),
+			createLogger: () => ({
+				error(message, meta) {
+					logs.push({ message, meta });
+				},
+				warn() {
+					// no-op for tests
+				},
+			}),
+		});
+
+		const specPath = "/path/to/component.spec.tsx";
+		const scenarioIndex = 3;
+
+		await expect(
+			adapter.capture({
+				specPath,
+				scenarioIndex,
+			})
+		).rejects.toThrow("module not found");
+
+		expect(logs).toHaveLength(1);
+		expect(logs[0]?.message).toContain(specPath);
+		expect(logs[0]?.message).toContain(String(scenarioIndex));
+		expect(logs[0]?.meta?.specPath).toBe(specPath);
+		expect(logs[0]?.meta?.scenarioIndex).toBe(scenarioIndex);
+		expect(logs[0]?.meta?.error).toBe("module not found");
+	});
+
+	test("captureAnimation uses same error handling", async () => {
+		const logs: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+		const adapter = new OpenTUITestAdapter({
+			importModule: () => Promise.reject(new Error("boom")),
+			render: () => Promise.resolve(),
+			createLogger: () => ({
+				error(message, meta) {
+					logs.push({ message, meta });
+				},
+				warn() {
+					// no-op for tests
+				},
+			}),
+		});
+
+		const specPath = "/path/to/component.spec.tsx";
+		const scenarioIndex = 1;
+
+		await expect(
+			adapter.captureAnimation({
+				specPath,
+				scenarioIndex,
+				animation: {
+					duration: 400,
+					screenshots: 5,
+				},
+			})
+		).rejects.toThrow("boom");
+
+		expect(logs).toHaveLength(1);
+		expect(logs[0]?.message).toContain(specPath);
+		expect(logs[0]?.message).toContain(String(scenarioIndex));
+	});
+});

--- a/src/testing/capture/adapters/opentui.ts
+++ b/src/testing/capture/adapters/opentui.ts
@@ -1,0 +1,156 @@
+import { pathToFileURL } from "node:url";
+import { render } from "@opentui/react";
+import type { ReactNode } from "react";
+import { testLogger } from "@/services/logger";
+
+export type ScenarioDefinition = {
+	/** Display name for the scenario */
+	scenarioName: string;
+	/** Description of the rendered scenario */
+	description: string;
+	/** React factory that returns the node to render */
+	render: () => ReactNode;
+	/** Optional cleanup invoked after rendering */
+	cleanup?: () => void | Promise<void>;
+};
+
+export type ScenarioModule = {
+	default: {
+		scenarios: ScenarioDefinition[];
+	};
+};
+
+export type CaptureOptions = {
+	/** Absolute path to the component spec module */
+	specPath: string;
+	/** Index of the scenario within the spec module */
+	scenarioIndex: number;
+};
+
+export type AnimationCaptureOptions = CaptureOptions & {
+	animation: {
+		duration: number;
+		screenshots: number;
+	};
+};
+
+type Logger = {
+	error(message: string, meta?: Record<string, unknown>): void;
+	warn(message: string, meta?: Record<string, unknown>): void;
+};
+
+type AdapterDependencies = {
+	importModule: (specifier: string) => Promise<ScenarioModule>;
+	render: typeof render;
+	createLogger: (context: {
+		specPath: string;
+		scenarioIndex: number;
+	}) => Logger;
+};
+
+const defaultDependencies: AdapterDependencies = {
+	importModule: async (specifier) =>
+		import(specifier) as Promise<ScenarioModule>,
+	render,
+	createLogger: ({ specPath, scenarioIndex }) =>
+		testLogger.child({
+			adapter: "OpenTUITestAdapter",
+			specPath,
+			scenarioIndex,
+		}),
+};
+
+export class OpenTUITestAdapter {
+	private readonly dependencies: AdapterDependencies;
+
+	constructor(dependencies: Partial<AdapterDependencies> = {}) {
+		this.dependencies = { ...defaultDependencies, ...dependencies };
+	}
+
+	async capture(options: CaptureOptions): Promise<void> {
+		await this.withScenario(options);
+	}
+
+	async captureAnimation(options: AnimationCaptureOptions): Promise<void> {
+		await this.withScenario(options);
+	}
+
+	private async withScenario<T>(
+		{ specPath, scenarioIndex }: CaptureOptions,
+		handler?: (scenario: ScenarioDefinition) => Promise<T> | T
+	): Promise<T | undefined> {
+		const logger = this.dependencies.createLogger({ specPath, scenarioIndex });
+		let cleanup: (() => void | Promise<void>) | undefined;
+
+		try {
+			const module = await this.dependencies.importModule(
+				this.toImportSpecifier(specPath)
+			);
+			const scenario = this.getScenario(module, scenarioIndex, specPath);
+			const node = scenario.render();
+
+			cleanup = scenario.cleanup;
+
+			await this.dependencies.render(node);
+			if (handler) {
+				return await handler(scenario);
+			}
+			return;
+		} catch (error) {
+			const actualError =
+				error instanceof Error ? error : new Error(String(error));
+
+			logger.error(
+				`Failed to import or render scenario ${scenarioIndex} from ${specPath}`,
+				{
+					specPath,
+					scenarioIndex,
+					error: actualError.message,
+				}
+			);
+
+			throw actualError;
+		} finally {
+			if (cleanup) {
+				try {
+					await cleanup();
+				} catch (cleanupError) {
+					const actualCleanupError =
+						cleanupError instanceof Error
+							? cleanupError
+							: new Error(String(cleanupError));
+					logger.warn("Scenario cleanup failed", {
+						specPath,
+						scenarioIndex,
+						error: actualCleanupError.message,
+					});
+				}
+			}
+		}
+	}
+
+	private toImportSpecifier(specPath: string): string {
+		if (specPath.startsWith("file://")) {
+			return specPath;
+		}
+
+		return pathToFileURL(specPath).href;
+	}
+
+	private getScenario(
+		module: ScenarioModule,
+		scenarioIndex: number,
+		specPath: string
+	): ScenarioDefinition {
+		const scenarios = module?.default?.scenarios ?? [];
+		const scenario = scenarios[scenarioIndex];
+
+		if (!scenario) {
+			throw new Error(
+				`Scenario ${scenarioIndex} not found in spec ${specPath}`
+			);
+		}
+
+		return scenario;
+	}
+}


### PR DESCRIPTION
## Summary
- add an OpenTUI test adapter scaffold that wraps module import and rendering in try/catch/finally and logs spec metadata on failure
- ensure animation capture uses the same error handling path while keeping cleanup in finally
- cover import failures with unit tests that assert the logger message includes the spec path and scenario index

## Testing
- bun test src/testing/capture/adapters/opentui.test.ts
- bun x tsc --noEmit *(fails: missing optional playwright and node-pty dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0157818883328a5da7a65b95bfb8